### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 
 ### How to install
 
+#### Prerequisites
+
+This package depends on python3-speedtest-cli which in turn depends on python3-base and various other python3 libraries. These packages combined can take up a lot of space on a router so before installing luci-app-netspeedtest, make sure you have enough space to install python3-speedtest-cli. You can check this by searching for python3-speedtest-cli under the software page in LuCI and try to install it, it will tell you how much space it and its dependencies require, just compare that to how much space you have left.
+
+#### Installation
+
 1. Goto [releases](https://github.com/muink/luci-app-netspeedtest/tree/releases)
 2. Download the latest version of ipk
 3. Login router and goto **System --> Software**


### PR DESCRIPTION
Add cautionary text about space requirement of dependencies. If one tries to install luci-app-netspeedtest without having enough space on their device, which they will not notice until they've started the installation, they will end up with a bunch of dangling python packages. If they then do not have opkg logging to file on which by default is off in openwrt, they will have a router with full memory and no log of which packages are half installed and can be removed.

The only way to get out of this is to either know of all dependencies and remove them manually or run a script that tries to uninstall all dependent packages with --autoremove one by one which is taxing on a router processor.

The above happened to me so I wanted to add this disclaimer to the README so nobody else has to go through it.